### PR TITLE
fix errors when upgrading

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,7 +59,7 @@ logstash_major_ver: '5.x'  # Define major version to install
 # Defines the miniumum amount of memory (in MB) required to effectively run Logstash
 logstash_min_memory_required: 1024
 
-logstash_minor_ver: '1:5.*'  # Define minor version to install
+logstash_minor_ver: '1:5.3.3-1'  # Define minor version to install also defines Pin priority on APT Preferences.d
 logstash_plugins:
 #  - 'logstash-codec-nmap'
   - 'logstash-filter-elasticsearch'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,7 +59,7 @@ logstash_major_ver: '5.x'  # Define major version to install
 # Defines the miniumum amount of memory (in MB) required to effectively run Logstash
 logstash_min_memory_required: 1024
 
-logstash_minor_ver: '1:5.2.0-1'  # Define minor version to install
+logstash_minor_ver: '1:5.*'  # Define minor version to install
 logstash_plugins:
 #  - 'logstash-codec-nmap'
   - 'logstash-filter-elasticsearch'

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -34,6 +34,7 @@
   apt:
     name: "logstash={{ logstash_minor_ver }}"
     state: "present"
+    force: yes  # This is required to allow downgrade if user desires to move back to previous version
   # notify: "init logstash"
   # when: ansible_distribution !=
 

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -22,6 +22,14 @@
     state: "present"
   when: logstash_install_java
 
+- name: debian | assigning Pin priority 1001 on APT Preferences
+  template:
+    src: "etc/apt/preferences.d/logstash.j2"
+    dest: "/etc/apt/preferences.d/logstash"
+    user: root
+    group: root
+    mode: 0644
+
 - name: debian | Installing Logstash
   apt:
     name: "logstash={{ logstash_minor_ver }}"

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -26,7 +26,7 @@
   template:
     src: "etc/apt/preferences.d/logstash.j2"
     dest: "/etc/apt/preferences.d/logstash"
-    user: root
+    owner: root
     group: root
     mode: 0644
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,13 +20,13 @@
     - logstash
   when: ansible_os_family == "RedHat"
 
-- include: config_logstash.yml
-  when: config_logstash
-
 - include: plugins.yml
   tags:
     - logstash
     - logstash_plugins
+
+- include: config_logstash.yml
+  when: config_logstash
 
 - include: validate_permissions.yml
   tags:

--- a/templates/etc/apt/preferences.d/logstash.j2
+++ b/templates/etc/apt/preferences.d/logstash.j2
@@ -1,0 +1,4 @@
+
+Package: logstash
+Pin: version {{ logstash_minor_ver }}
+Pin-Priority: 1001


### PR DESCRIPTION
This fixes errors when apt upgraded logstash package. 
Also order fixes error when config has a reference to a plugin not installed yet, so first install additional plugins, then config, then test the config is the correct order. 