### PR TITLE
added 'apt update' task after repo addition

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -15,10 +15,12 @@
   apt_repository:
     repo: "{{ logstash_deb_repo }}"
     state: "present"
+  register: "_logstash_repo_added"    
 
-- name: Run "apt-get update" 
+- name: debian | Updating apt-cache 
   apt:
     update_cache: yes
+  when: _logstash_repo_added['changed']
 
 - name: debian | installing java
   apt:

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -16,6 +16,10 @@
     repo: "{{ logstash_deb_repo }}"
     state: "present"
 
+- name: Run "apt-get update" 
+  apt:
+    update_cache: yes
+
 - name: debian | installing java
   apt:
     name: "openjdk-{{ openjdk_version }}-jre-headless"


### PR DESCRIPTION
At lest on Ubuntu 16.04 "logstash" package was not found during install without running "apt update" after adding elastic repo. So added "apt update" step before  after repo addition.