### PR TITLE
enable settings to work behind proxy with auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ logstash_plugins:
   - 'logstash-input-beats'
 #  - 'logstash-output-jira'
   - 'logstash-output-slack'
+logstash_plugin_cmd_vars: "JARS_SKIP='true'"
+# Other examples:
+# Options to work with proxy
+# logstash_plugin_cmd_vars: "JARS_SKIP='true' JRUBY_OPTS='-J-Dhttps.proxyHost=user:password@proxy.com -J-Dhttps.proxyPort=8080 -J-Dhttp.proxyHost=user:password@proxy.com -J-Dhttp.proxyPort=8080'"
 logstash_repo_key: 'https://artifacts.elastic.co/GPG-KEY-elasticsearch'
 logstash_repo_url: 'https://artifacts.elastic.co/packages/{{ logstash_major_ver }}/yum'
 logstash_server_fqdn: 'logstash.{{ pri_domain_name }}'  #defines logstash server to send to...fqdn or localhost
@@ -114,32 +118,32 @@ Use your own outputs:
 
 Example:
 
-```
+```yaml
 
 logstash_custom_outputs:
   - output: 'gelf'
     lines:
       - 'host => "localhost"'
-      - 'port => "12201"'    
+      - 'port => "12201"'
 ```
 
 Additional variables for customized configs:
 
 ```yaml
 
-logstash_custom_inputs: 
+logstash_custom_inputs:
   - input: someinput
     lines:
       - 'somekey => "value"'
 
-logstash_custom_filters: 
+logstash_custom_filters:
   - lines:
       - 'somekey => "value"'
-  
-logstash_custom_outputs: 
+
+logstash_custom_outputs:
   - output: someoutput
     lines:
-      - 'somekey => "value"'  
+      - 'somekey => "value"'
 
 ```
 
@@ -188,6 +192,7 @@ Author Information
 ------------------
 
 Larry Smith Jr.
+
 - @mrlesmithjr
 - http://everythingshouldbevirtual.com
 - mrlesmithjr [at] gmail.com

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -71,6 +71,13 @@ logstash_plugins:
   - 'logstash-output-email'
 #  - 'logstash-output-jira'
   - 'logstash-output-slack'
+
+# https://github.com/elastic/logstash/issues/6528
+logstash_plugin_cmd_vars: "JARS_SKIP='true'"
+# Other examples:
+# Options to work with proxy
+# logstash_plugin_cmd_vars: "JARS_SKIP='true' JRUBY_OPTS='-J-Dhttps.proxyHost=user:password@proxy.com -J-Dhttps.proxyPort=8080 -J-Dhttp.proxyHost=user:password@proxy.com -J-Dhttp.proxyPort=8080'"
+
 logstash_repo_key: 'https://artifacts.elastic.co/GPG-KEY-elasticsearch'
 logstash_repo_url: 'https://artifacts.elastic.co/packages/{{ logstash_major_ver }}/yum'
 logstash_server_fqdn: 'logstash.{{ pri_domain_name }}'  #defines logstash server to send to...fqdn or localhost

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -10,7 +10,7 @@
   changed_when: false
 
 - name: plugins | installing logstash plugins
-  command: "{{ logstash_plugin_bin }} install {{ item }}"
+  shell: "{{ logstash_plugin_cmd_vars }} {{ logstash_plugin_bin }} install {{ item }}"
   notify: "restart logstash"
   with_items: '{{ logstash_plugins }}'
   when: item not in logstash_plugins_installed.stdout


### PR DESCRIPTION
Something changed in latest versions of logstash that broke installing plugins behind authenticated proxies in same way as it was working before. 
Now checking https://github.com/elastic/logstash/issues/6528 I have found additional vars to add in command line that makes it work again. 

These changes adds the option to get it working on such special scenarios (normal on many enterprises). 