### PR TITLE
Adds The logstash_system_groups Variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -123,3 +123,6 @@ logstash_server_fqdn: "logstash.{{ logstash_pri_domain_name }}"
 logstash_pri_domain_name: example.org
 
 logstash_install_java: true
+
+# Defines the system groups the logstash user should be part of
+logstash_system_groups: []

--- a/tasks/config_logstash.yml
+++ b/tasks/config_logstash.yml
@@ -50,6 +50,12 @@
     - /opt/logstash/lib/logstash/outputs/elasticsearch
     - /opt/logstash/patterns
 
+- name: config_logstash | add the logstash user to system groups
+  user:
+    name: "{{ logstash_system_user }}"
+    groups: "{{ logstash_system_groups | join(',') }}"
+    append: no
+
 - name: config_logstash | test logstash configuration
   shell: "{{ logstash_bin }} -t -f {{ logstash_config_dir }} --path.settings /etc/logstash/"
   become: true

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,3 @@
 ---
 # vars file for ansible-logstash
+logstash_system_user: "logstash"


### PR DESCRIPTION
Adding the logstash_system_groups variable will allow us to specify
which system groups the logstash user will be part of.

Fixes mrlesmithjr/ansible-logstash#18