### PR TITLE
Use the Logstash User and Group Vars Globally

### DIFF
--- a/tasks/config_logstash.yml
+++ b/tasks/config_logstash.yml
@@ -12,8 +12,8 @@
   file:
     path: "{{ logstash_config_dir }}"
     state: directory
-    owner: logstash
-    group: logstash
+    owner: "{{ logstash_system_user }}"
+    group: "{{ logstash_system_group }}"
     mode: u=rwx,g=rx,o=rx
   become: true
 
@@ -28,8 +28,8 @@
   template:
     src: "{{ 'etc/logstash/conf.d/' + item + '.conf.j2' }}"
     dest: "{{ logstash_config_dir + '/' + item + '.conf' }}"
-    owner: logstash
-    group: logstash
+    owner: "{{ logstash_system_user }}"
+    group: "{{ logstash_system_group }}"
     mode: u=rw,g=r,o=r
     #validate: "/opt/logstash/bin/logstash -tf %s" # commented due to error during tests with file not found.
   become: true
@@ -41,8 +41,8 @@
   file:
     path: "{{ item }}"
     state: directory
-    owner: logstash
-    group: logstash
+    owner: "{{ logstash_system_user }}"
+    group: "{{ logstash_system_group }}"
     mode: 0775
     recurse: true
   become: true

--- a/tasks/validate_permissions.yml
+++ b/tasks/validate_permissions.yml
@@ -4,7 +4,7 @@
     path: "{{ logstash_folder }}"
     state: directory
     recurse: true
-    owner: logstash
-    group: logstash
+    owner: "{{ logstash_system_user }}"
+    group: "{{ logstash_system_group }}"
   become: true
   notify: restart logstash

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,5 @@
 ---
 # vars file for ansible-logstash
 logstash_system_user: "logstash"
+# the logstash user's primary group
+logstash_system_group: "logstash"


### PR DESCRIPTION
Since the logstash_system_user role variable has been deemed as
acceptable for defining the system user, migrate all the tasks to use
that variable (when referring to the user) and logstash_system_group for
the user's primary group.