### PR TITLE
Use '~' instead of '+' for string concatenation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -73,7 +73,7 @@ logstash_custom_outputs:
   #   lines:
   #     - 'somekey => "value"'
 
-logstash_deb_repo: "{{ 'deb https://artifacts.elastic.co/packages/' + logstash_major_ver + '/apt stable main' }}"
+logstash_deb_repo: "{{ 'deb https://artifacts.elastic.co/packages/' ~ logstash_major_ver ~ '/apt stable main' }}"
 logstash_folder: /opt/logstash
 logstash_log_dir: /var/log/logstash
 
@@ -115,7 +115,7 @@ logstash_plugin_cmd_vars: "JARS_SKIP='true'"
 # Options to work with proxy
 # logstash_plugin_cmd_vars: "JARS_SKIP='true' JRUBY_OPTS='-J-Dhttps.proxyHost=user:password@proxy.com -J-Dhttps.proxyPort=8080 -J-Dhttp.proxyHost=user:password@proxy.com -J-Dhttp.proxyPort=8080'"
 
-logstash_redhat_repo_url: "{{ 'https://artifacts.elastic.co/packages/' + logstash_major_ver + '/yum' }}"
+logstash_redhat_repo_url: "{{ 'https://artifacts.elastic.co/packages/' ~ logstash_major_ver ~ '/yum' }}"
 
 logstash_repo_key: https://artifacts.elastic.co/GPG-KEY-elasticsearch
 

--- a/tasks/config_logstash.yml
+++ b/tasks/config_logstash.yml
@@ -19,15 +19,15 @@
 
 - name: config_logstash | removing original logstash config if it exists
   file:
-    path: "{{ logstash_config_dir + '/logstash.conf' }}"
+    path: "{{ logstash_config_dir ~ '/logstash.conf' }}"
     state: absent
   become: true
   notify: restart logstash
 
 - name: config_logstash | configuring logstash
   template:
-    src: "{{ 'etc/logstash/conf.d/' + item + '.conf.j2' }}"
-    dest: "{{ logstash_config_dir + '/' + item + '.conf' }}"
+    src: "{{ 'etc/logstash/conf.d/' ~ item ~ '.conf.j2' }}"
+    dest: "{{ logstash_config_dir ~ '/' ~ item ~ '.conf' }}"
     owner: "{{ logstash_system_user }}"
     group: "{{ logstash_system_group }}"
     mode: u=rw,g=r,o=r

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -32,7 +32,7 @@
 
 - name: debian | installing java
   apt:
-    name: "{{ 'openjdk-' + logstash_openjdk_version + '-jre-headless' }}"
+    name: "{{ 'openjdk-' ~ logstash_openjdk_version ~ '-jre-headless' }}"
     state: present
   become: true
   register: result
@@ -50,7 +50,7 @@
 
 - name: debian | Installing Logstash
   apt:
-    name: "{{ 'logstash=' + logstash_minor_ver }}"
+    name: "{{ 'logstash=' ~ logstash_minor_ver }}"
     state: present
     # This is required to allow downgrade if user desires to move back
     # to previous version

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -15,7 +15,7 @@
 
 - name: redhat | installing java
   yum:
-    name: ["{{ 'java-1.' + logstash_openjdk_version + '.0-openjdk' }}"]
+    name: ["{{ 'java-1.' ~ logstash_openjdk_version ~ '.0-openjdk' }}"]
     state: present
   become: true
   register: result


### PR DESCRIPTION
Use `~` during string concatenation as it converts all operands into
strings first. `+` operator is not preferred for string concatenation.
https://jinja.palletsprojects.com/en/2.11.x/templates/#other-operators

Fixes mrlesmithjr#25